### PR TITLE
Fix an edge case when binding directly to an instance

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -424,7 +424,7 @@ class Binder(object):
         elif isinstance(interface, (tuple, type)) and isinstance(to, interface):
             return InstanceProvider(to)
         elif issubclass(type(interface), type) or isinstance(interface, (tuple, list)):
-            if issubclass(interface, (BaseKey, BaseMappingKey, BaseSequenceKey)) and to is not None:
+            if to is not None:
                 return InstanceProvider(to)
             return ClassProvider(interface)
         elif hasattr(interface, '__call__'):

--- a/injector_test.py
+++ b/injector_test.py
@@ -1185,3 +1185,15 @@ def test_special_interfaces_work_with_auto_bind_disabled():
 
     # This used to fail with an error similar to the ProviderOf one
     injector.get(AssistedBuilder(cls=InjectMe))
+
+
+def test_binding_an_instance_regression():
+    text = b'hello'.decode()
+    def configure(binder):
+        # Yes, this binding doesn't make sense strictly speaking but
+        # it's just a sample case.
+        binder.bind(bytes, to=text)
+
+    injector = Injector(configure)
+    # This used to return empty bytes instead of the expected string
+    assert injector.get(bytes) == text


### PR DESCRIPTION
@alecthomas I ended up with ``binder.bind(bytes, to=u'hello')`` in an unrelated piece of code for a reason that doesn't matter here - turns out such binding didn't really work and when ``bytes`` were being requested.

This is the simplest way I could make the test work, I'm not pushing this directly to master as the logic behind that whole ``if/elif/else`` block has subtleties that may escape me. It didn't break any existing tests so there's that.