### PR TITLE
Add default scope support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docs/_build/
 build/
 htmlcov/
 *,cover
+.python-version
+.idea

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Injector Change Log
 ===================
 
+0.14.0
+------
+
+- Add default scope support
+
 0.13.1
 ------
 

--- a/injector.py
+++ b/injector.py
@@ -30,7 +30,7 @@ TYPING353 = hasattr(Union[str, int], '__origin__')
 
 
 __author__ = 'Alec Thomas <alec@swapoff.org>'
-__version__ = '0.13.1'
+__version__ = '0.14.0'
 __version_tag__ = ''
 
 log = logging.getLogger('injector')
@@ -265,17 +265,20 @@ class Binder:
     """
 
     @private
-    def __init__(self, injector, auto_bind=True, parent=None):
+    def __init__(self, injector, auto_bind=True, parent=None, scope=None):
         """Create a new Binder.
 
         :param injector: Injector we are binding for.
         :param auto_bind: Whether to automatically bind missing types.
         :param parent: Parent binder.
+        :param scope: Default scope used, when no scope is provided
+            in :meth:`Binder.bind` method. :class:`NoScope` is used by default.
         """
         self.injector = injector
         self._auto_bind = auto_bind
         self._bindings = {}
         self.parent = parent
+        self.scope = scope or NoScope
 
     def bind(self, interface, to=None, scope=None):
         """Bind an interface to an implementation.
@@ -383,7 +386,7 @@ class Binder:
 
     def create_binding(self, interface, to=None, scope=None):
         provider = self.provider_for(interface, to)
-        scope = scope or getattr(to or interface, '__scope__', NoScope)
+        scope = scope or getattr(to or interface, '__scope__', self.scope)
         if isinstance(scope, ScopeDecorator):
             scope = scope.scope
         return Binding(interface, provider, scope)
@@ -623,6 +626,8 @@ class Injector:
 
     :param auto_bind: Whether to automatically bind missing types.
     :param parent: Parent injector.
+    :param scope: Scope of created objects, if no scope provided. Default:
+                  :class:`NoScope`.
 
     If you use Python 3 you can make Injector use constructor parameter annotations to
     determine class dependencies. The following code::
@@ -643,9 +648,12 @@ class Injector:
 
     .. versionchanged:: 0.13.0
         ``use_annotations`` parameter is removed
+
+    .. versionchanged:: 0.14.0
+        ``scope`` parameter added
     """
 
-    def __init__(self, modules=None, auto_bind=True, parent=None):
+    def __init__(self, modules=None, auto_bind=True, parent=None, scope=None):
         # Stack of keys currently being injected. Used to detect circular
         # dependencies.
         self._stack = ()
@@ -653,7 +661,8 @@ class Injector:
         self.parent = parent
 
         # Binder
-        self.binder = Binder(self, auto_bind=auto_bind, parent=parent and parent.binder)
+        self.binder = Binder(self, auto_bind=auto_bind,
+                             parent=parent and parent.binder, scope=scope)
 
         if not modules:
             modules = []

--- a/injector_test.py
+++ b/injector_test.py
@@ -1249,3 +1249,14 @@ def test_class_assisted_builder_of_partially_injected_class():
     assert isinstance(c, C)
     assert isinstance(c.b, B)
     assert isinstance(c.b.a, A)
+
+
+def test_default_scope_settings():
+    class A:
+        pass
+
+    i1 = Injector()
+    assert i1.get(A) is not i1.get(A)
+
+    i2 = Injector(scope=singleton)
+    assert i2.get(A) is i2.get(A)


### PR DESCRIPTION
Hello!

I added support for default scope to injector.

This removes a lot of boiler plate, in projects that use other scopes than NoScope by default. For example, a lot of programs, use DI to store services, which are singletons. If this is merged, it will allow, to specify default scope, when creating Injector instance. 

Thanks for all your work!

P.S. About version number: I assumed injector uses semantic versioning, this is why I set the new version to 0.14.0. I can correct it if this is necessary.  