### PR TITLE
Fix scope and parent/child injector interaction

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,16 @@
 Injector Change Log
 ===================
 
+0.14.0 (not released yet)
+------
+
+- Fixed a bug with values shared between Injectors in a hierarchy (bugs #52 and #72)
+
+Backwards incompatible:
+
+- If you use a custom scope with child Injectors you need to bind the scope not only with the
+  root Injector but also the children
+
 0.13.1
 ------
 

--- a/CHANGES
+++ b/CHANGES
@@ -5,11 +5,7 @@ Injector Change Log
 ------
 
 - Fixed a bug with values shared between Injectors in a hierarchy (bugs #52 and #72)
-
-Backwards incompatible:
-
-- If you use a custom scope with child Injectors you need to bind the scope not only with the
-  root Injector but also the children
+- Binding scopes explicitly (``Binder.bind_scope``) is no longer necessary and ``bind_scope`` is a no-op now.
 
 0.13.1
 ------

--- a/injector_test.py
+++ b/injector_test.py
@@ -1272,3 +1272,22 @@ def test_child_scope():
     assert first_child_injector.get(TestKey) is first_child_injector.get(TestKey)
     assert first_child_injector.get(TestKey) is second_child_injector.get(TestKey)
     assert first_child_injector.get(TestKey2) is not second_child_injector.get(TestKey2)
+
+
+def test_custom_scopes_work_as_expected_with_child_injectors():
+    class CustomSingletonScope(SingletonScope):
+        pass
+
+    custom_singleton = ScopeDecorator(CustomSingletonScope)
+
+    def parent_module(binder):
+        binder.bind(str, to='parent value', scope=custom_singleton)
+
+    def child_module(binder):
+        binder.bind(str, to='child value', scope=custom_singleton)
+
+    parent = Injector(modules=[parent_module])
+    child = parent.create_child_injector(modules=[child_module])
+    print('parent, child: %s, %s' % (parent, child))
+    assert parent.get(str) == 'parent value'
+    assert child.get(str) == 'child value'

--- a/injector_test.py
+++ b/injector_test.py
@@ -1249,3 +1249,26 @@ def test_class_assisted_builder_of_partially_injected_class():
     assert isinstance(c, C)
     assert isinstance(c.b, B)
     assert isinstance(c.b.a, A)
+
+
+# The test taken from Alec Thomas' pull request: https://github.com/alecthomas/injector/pull/73
+def test_child_scope():
+    TestKey = Key('TestKey')
+    TestKey2 = Key('TestKey2')
+
+    def parent_module(binder):
+        binder.bind(TestKey, to=object, scope=singleton)
+
+    def first_child_module(binder):
+        binder.bind(TestKey2, to=object, scope=singleton)
+
+    def second_child_module(binder):
+        binder.bind(TestKey2, to='marker', scope=singleton)
+
+    injector = Injector(modules=[parent_module])
+    first_child_injector = injector.create_child_injector(modules=[first_child_module])
+    second_child_injector = injector.create_child_injector(modules=[second_child_module])
+
+    assert first_child_injector.get(TestKey) is first_child_injector.get(TestKey)
+    assert first_child_injector.get(TestKey) is second_child_injector.get(TestKey)
+    assert first_child_injector.get(TestKey2) is not second_child_injector.get(TestKey2)


### PR DESCRIPTION
This is an alternative to https://github.com/alecthomas/injector/pull/73


The issue was that even though some bindings may have been local to
a child Injector only the root Injector actually had the scope objects
which were shared among all Injectors in a hierarchy. Due to that when
an object was stored in a scope it was being stored in the single (per
hierarchy) shared scope.

This patch removes the arbitrary limitation and all Injectors have
scopes bound locally now.

It's worth noting that while the Scope interface doesn't change here
this patch still breaks backwards compatibility - custom scopes need to
be provided to all Injector instantiations, not only the root one.

This may introduce some subtle issues but I can't think of any right
now.