### PR TITLE
Fix error message when using AssistedBuilder with a provider

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -1199,7 +1199,7 @@ class AssistedBuilder(Generic[T]):
         if not isinstance(provider, ClassProvider):
             raise Error(
                 'Assisted interface building works only with ClassProviders, '
-                'got %r for %r' % (provider, self.interface))
+                'got %r for %r' % (provider, binding.interface))
 
         return self._build_class(provider._cls, **kwargs)
 

--- a/injector_test.py
+++ b/injector_test.py
@@ -25,6 +25,7 @@ from injector import (
     CircularDependency, Module, Key, SingletonScope,
     ScopeDecorator, with_injector, AssistedBuilder, BindingKey,
     SequenceKey, MappingKey, provider, ProviderOf, ClassAssistedBuilder,
+    Error,
     )
 
 
@@ -1312,3 +1313,18 @@ def test_inject_decorator_does_not_break_manual_construction_of_pyqt_objects():
     instance = PyQtFake()  # This used to raise the exception
 
     assert isinstance(instance, PyQtFake)
+
+
+def test_using_an_assisted_builder_with_a_provider_raises_an_injector_error():
+    class A:
+        pass
+
+    class MyModule(Module):
+        @provider
+        def provide_a(self, builder: AssistedBuilder[A]) -> A:
+            return builder.build()
+
+    injector = Injector(MyModule)
+
+    with pytest.raises(Error):
+        injector.get(A)


### PR DESCRIPTION
Previously the exception was:
```
AttributeError: 'AssistedBuilder' object has no attribute 'interface'
```

Now it is:
```
injector.Error: Assisted interface building works only with ClassProviders, got CallableProvider(<bound method test_using_an_assisted_builder_with_a_provider_raises_an_injector_error.<locals>.MyModule.provide_a of <injector_test.test_using_an_assisted_builder_with_a_provider_raises_an_injector_error.<locals>.MyModule object at 0x10f1174a8>>) for <class 'injector_test.test_using_an_assisted_builder_with_a_provider_raises_an_injector_error.<locals>.A'>
```