### PR TITLE
Add type hints

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Injector Change Log
 -------------------------
 
 - Added NewType support
+- Added type hints
 
 0.13.4
 ------

--- a/injector.py
+++ b/injector.py
@@ -39,6 +39,8 @@ log.addHandler(logging.NullHandler())
 if log.level == logging.NOTSET:
     log.setLevel(logging.WARN)
 
+T = TypeVar('T')
+
 
 def private(something):
     something.__private__ = True
@@ -675,7 +677,7 @@ class Injector:
     def _log_prefix(self):
         return '>' * (len(self._stack) + 1) + ' '
 
-    def get(self, interface, scope=None):
+    def get(self, interface: T, scope=None) -> T:
         """Get an instance of the given interface.
 
         .. note::
@@ -1194,9 +1196,6 @@ class BoundKey(tuple):
         return dict(self[1])
 
 
-T = TypeVar('T')
-
-
 class AssistedBuilder(Generic[T]):
 
     def __init__(self, injector, target):
@@ -1258,7 +1257,7 @@ class ProviderOf(Generic[T]):
         return '%s(%r, %r)' % (
             type(self).__name__, self._injector, self._interface)
 
-    def get(self):
+    def get(self) -> T:
         """Get an implementation for the specified interface."""
         return self._injector.get(self._interface)
 


### PR DESCRIPTION
Let me start by saying I'm a big fan of this library and happy to finally contribute!

This PR helps with giving type hints in those cases where you need to do `injector.get`.

Here's an example:
![image](https://user-images.githubusercontent.com/1594505/41504490-90987bbe-71be-11e8-8a27-f3da81c94b02.png)

Previously I could do `c: C = Injector().get(C)` in Python 3.6+ but it was getting annoying.