### PR TITLE
Raise when marking a non-existent argument as noninjectable

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -114,6 +114,10 @@ class UnknownProvider(Error):
     """Tried to bind to a type whose provider couldn't be determined."""
 
 
+class UnknownArgument(Error):
+    """Tried to mark an unknown argument as noninjectable."""
+
+
 class Provider:
     """Provides class instances."""
 
@@ -1071,6 +1075,12 @@ def noninjectable(*args):
     doesn't matter.
     """
     def decorator(function):
+        bindings = _infer_injected_bindings(function)
+        for arg in args:
+            if arg not in bindings:
+                raise UnknownArgument('Unable to mark unknown argument %s '
+                                      'as non-injectable.' % arg)
+
         existing = getattr(function, '__noninjectables__', set())
         merged = existing | set(args)
         function.__noninjectables__ = merged

--- a/injector_test.py
+++ b/injector_test.py
@@ -25,7 +25,7 @@ from injector import (
     CircularDependency, Module, Key, SingletonScope,
     ScopeDecorator, with_injector, AssistedBuilder, BindingKey,
     SequenceKey, MappingKey, provider, ProviderOf, ClassAssistedBuilder,
-    Error,
+    Error, UnknownArgument,
     )
 
 
@@ -1107,6 +1107,16 @@ def test_assisted_building_is_supported():
 
     processor = processor_builder.build(user_id=333, provider_id='not injected')
     assert processor.name == 'John'
+
+
+def test_raises_when_noninjectable_arguments_defined_with_invalid_arguments():
+    with pytest.raises(UnknownArgument):
+
+        class A:
+            @inject
+            @noninjectable('c')
+            def __init__(self, b: str):
+                self.b = b
 
 
 def test_implicit_injection_fails_when_annotations_are_missing():


### PR DESCRIPTION
Fixes #92.