### PR TITLE
Allow noninjectable arguments to be untyped

### DIFF
--- a/injector.py
+++ b/injector.py
@@ -1079,9 +1079,9 @@ def noninjectable(*args):
     doesn't matter.
     """
     def decorator(function):
-        bindings = _infer_injected_bindings(function)
+        argspec = inspect.getfullargspec(inspect.unwrap(function))
         for arg in args:
-            if arg not in bindings:
+            if arg not in argspec.args and arg not in argspec.kwonlyargs:
                 raise UnknownArgument('Unable to mark unknown argument %s '
                                       'as non-injectable.' % arg)
 

--- a/injector.py
+++ b/injector.py
@@ -1082,7 +1082,7 @@ def noninjectable(*args):
         argspec = inspect.getfullargspec(inspect.unwrap(function))
         for arg in args:
             if arg not in argspec.args and arg not in argspec.kwonlyargs:
-                raise UnknownArgument('Unable to mark unknown argument %s '
+                raise UnknownArgument('Unable to mark unknown argument \'%s\' '
                                       'as non-injectable.' % arg)
 
         existing = getattr(function, '__noninjectables__', set())

--- a/injector_test.py
+++ b/injector_test.py
@@ -1119,6 +1119,22 @@ def test_raises_when_noninjectable_arguments_defined_with_invalid_arguments():
                 self.b = b
 
 
+def test_can_create_instance_with_untyped_noninjectable_argument():
+    class Parent:
+        @inject
+        @noninjectable('child1', 'child2')
+        def __init__(self, child1, *, child2):
+            self.child1 = child1
+            self.child2 = child2
+
+    injector = Injector()
+    parent_builder = injector.get(AssistedBuilder[Parent])
+    parent = parent_builder.build(child1='injected1', child2='injected2')
+
+    assert parent.child1 == 'injected1'
+    assert parent.child2 == 'injected2'
+
+
 def test_implicit_injection_fails_when_annotations_are_missing():
     class A:
         def __init__(self, n):


### PR DESCRIPTION
I accidentally introduced a limitation in #97 which required arguments in `@noninjectable` to be typed, or an `UnknownArgument` would be raised. This is fixed here.