### PR TITLE
Travis CI: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ matrix:
   include:
     - { python: "3.7", dist: xenial, sudo: true }
 install:
-  - pip install pytest "typing$TYPING_VERSION" "pytest-cov>=2.5.1"
+  - pip install flake8 pytest "typing$TYPING_VERSION" "pytest-cov>=2.5.1"
   # mypy can't be installed on pypy
   - if [[ "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then pip install mypy ; fi
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - if [[ "${TRAVIS_PYTHON_VERSION}" == "3.7" ]] ; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics ; fi
 script:
   - py.test -vv --cov=injector --cov-branch --cov-report html --cov-report term
   - if [[ "${TRAVIS_PYTHON_VERSION}" != "pypy"* ]] ; then mypy injector.py ; fi


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/alecthomas/injector on Python 3.7.1

Current output...

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./runtest.py:2444:9: F821 undefined name 'do_exec'
        do_exec(co, module.__dict__)
        ^
./runtest.py:2468:5: F821 undefined name 'do_exec'
    do_exec(entry, locals())
    ^
2     F821 undefined name 'do_exec'
2
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree