### PR TITLE
Don't require typing_extensions on Python 3.9 unnecessarily

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,5 +69,5 @@ setup(
         'IoC',
         'Inversion of Control container',
     ],
-    install_requires=['typing_extensions>=3.7.4'],
+    install_requires=['typing_extensions>=3.7.4;python_version<"3.9"'],
 )


### PR DESCRIPTION
This needs new mypy release with updated typeshed, it'll keep failing for now.