### PR TITLE
Update docs for custom scopes

### DIFF
--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -74,6 +74,6 @@ Scopes can be retrieved from the injector, as with any other instance. They are 
     >>> injector.get(CustomScope) is injector.get(CustomScope)
     True
 
-Scopes have `configure` method that will be called once per each injector and can be used for any required initialization.
+Scopes have a `configure` method that will be called once per each injector and can be used for any required initialization.
 
 For scopes with a transient lifetime, such as those tied to HTTP requests, the usual solution is to use a thread or greenlet-local cache inside the scope. The scope is "entered" in some low-level code by calling a method on the scope instance that creates this cache. Once the request is complete, the scope is "left" and the cache cleared.

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -47,12 +47,6 @@ This can be used like so::
     class MyClass:
         pass
 
-Scopes are bound in modules with the :meth:`Binder.bind_scope` method::
-
-    class MyModule(Module):
-        def configure(self, binder):
-            binder.bind_scope(CustomScope)
-
 Scopes can be retrieved from the injector, as with any other instance. They are singletons across the life of the injector::
 
     >>> injector = Injector([MyModule()])

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -74,4 +74,6 @@ Scopes can be retrieved from the injector, as with any other instance. They are 
     >>> injector.get(CustomScope) is injector.get(CustomScope)
     True
 
+Scopes have `configure` method that will be called once per each injector and can be used for any required initialization.
+
 For scopes with a transient lifetime, such as those tied to HTTP requests, the usual solution is to use a thread or greenlet-local cache inside the scope. The scope is "entered" in some low-level code by calling a method on the scope instance that creates this cache. Once the request is complete, the scope is "left" and the cache cleared.

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -24,6 +24,27 @@ A (redundant) example showing all three methods::
         def provide_thing(self) -> Thing:
             return Thing()
 
+ThreadLocals
+``````````
+
+ThreadLocals (instances local to a thread) are declared by binding them in the ThreadLocalScope. Just like for Singletons, this can be done in three ways:
+
+1.  Decorating the class with `@threadlocal`.
+2.  Decorating a `@provider` decorated Module method with `@threadlocal`.
+3.  Explicitly calling `binder.bind(X, scope=threadlocal)`.
+
+A (redundant) example showing all three methods::
+
+    @threadlocal
+    class Thing: pass
+    class ThingModule(Module):
+        def configure(self, binder):
+            binder.bind(Thing, scope=threadlocal)
+        @threadlocal
+        @provider
+        def provide_thing(self) -> Thing:
+            return Thing()
+
 Implementing new Scopes
 ```````````````````````
 


### PR DESCRIPTION
Updated docs for Scopes. During implementing a custom Scope I noticed docs mention using `bind_scope` but the method has been removed some time ago and is no longer needed.

I decided to reflect that in docs to avoid further confusion. Also, I added a few words about built-in `ThreadLocalScope` and `configure` method.

Any feedback appreciated,
Seba

PS: I'd be grateful for adding `hacktoberfest-accepted` label to this PR when it's accepted, thanks!