### PR TITLE
Add conda package reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ The core values of Injector are:
   ```bash
   pip install injector
   ```
+* Conda-forge (installable, stable distributions): https://anaconda.org/conda-forge/injector. You can install it using conda:
+
+  ```bash
+  conda install -c conda-forge injector
+  ```
 
 * Documentation: https://injector.readthedocs.org
 * Change log: https://injector.readthedocs.io/en/latest/changelog.html


### PR DESCRIPTION
We recently added a conda wrapper of the PyPI package to conda-forge, installable through
```
conda install -c conda-forge injector 
```

This PR simply adds a reference to that package in the README, in case you want to advertise it directly in this repository as well. If you like, I can also make one maintainer of the conda package (it's mostly a trivial job).