### PR TITLE
Py39 generics support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Run tests
       run: |
         py.test -vv --cov=injector --cov-branch --cov-report html --cov-report term
-        if which mypy; then mypy injector ; fi
+        if which mypy; then mypy --show-error-codes injector ; fi
         if which black; then black --check . ; fi
     - name: Report coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/injector_test.py
+++ b/injector_test.py
@@ -29,7 +29,8 @@ from injector import (
     Scope,
     InstanceProvider,
     ClassProvider,
-    T, get_bindings,
+    T,
+    get_bindings,
     inject,
     multiprovider,
     noninjectable,
@@ -1486,6 +1487,7 @@ def test_get_bindings():
         assert get_bindings(function8) == {}
 
 
+@pytest.mark.xfail(sys.version_info != (3, 9), reason="Generic support only in 3.9")
 def test_inject_generic_class() -> None:
     class GenericClass(Generic[T]):
         pass
@@ -1503,3 +1505,6 @@ def test_inject_generic_class() -> None:
 
     assert isinstance(instance, InjectsGeneric)
     assert isinstance(instance.injected_generic, GenericClass)
+    # A parametrized generic class instance need to have __orig_class__
+    # without it's just an instance of a plain class
+    assert instance.injected_generic.__orig_class__ == GenericClass[str]

--- a/injector_test.py
+++ b/injector_test.py
@@ -11,7 +11,7 @@
 """Functional tests for the "Injector" dependency injection framework."""
 
 from contextlib import contextmanager
-from typing import Any, NewType
+from typing import Any, Generic, NewType
 import abc
 import sys
 import threading
@@ -29,7 +29,7 @@ from injector import (
     Scope,
     InstanceProvider,
     ClassProvider,
-    get_bindings,
+    T, get_bindings,
     inject,
     multiprovider,
     noninjectable,
@@ -1484,3 +1484,22 @@ def test_get_bindings():
             pass
 
         assert get_bindings(function8) == {}
+
+
+def test_inject_generic_class() -> None:
+    class GenericClass(Generic[T]):
+        pass
+
+    class InjectsGeneric:
+        @inject
+        def __init__(self, injected_generic: GenericClass[str]):
+            self.injected_generic = injected_generic
+
+    def bindings(binder: Binder) -> None:
+        binder.bind(GenericClass)
+
+    injector = Injector(bindings)
+    instance = injector.get(InjectsGeneric)
+
+    assert isinstance(instance, InjectsGeneric)
+    assert isinstance(instance.injected_generic, GenericClass)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py36, py37, py39, py310, pypy3
+[testenv]
+usedevelop = True
+deps =
+    -rrequirements.txt
+    -rrequirements-dev.txt
+commands =
+    pytest {posargs}


### PR DESCRIPTION
I tried to add suport for generics in py39 and make the test from #175 pass.

I don't know what I am doing — python typing scares me :) — but I hope this will help to support generics in modern python versions. 

Any comments appreciated.