### PR TITLE
fix: inspect union arguments for annotations

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -1196,7 +1196,11 @@ def _infer_injected_bindings(callable: Callable, only_explicit_bindings: bool) -
                 for metadata in getattr(member, '__metadata__', tuple())
                 if _is_specialization(member, Annotated)
             }
-            if only_explicit_bindings and _inject_marker not in union_metadata or _noinject_marker in union_metadata:
+            if (
+                only_explicit_bindings
+                and _inject_marker not in union_metadata
+                or _noinject_marker in union_metadata
+            ):
                 del bindings[k]
             else:
                 bindings[k] = new_union  # type: ignore

--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -1209,7 +1209,16 @@ def _infer_injected_bindings(callable: Callable, only_explicit_bindings: bool) -
             # mypy complains about this construct:
             #     error: The type alias is invalid in runtime context
             # See: https://github.com/python/mypy/issues/5354
-            bindings[k] = new_union  # type: ignore
+            union_metadata = {
+                metadata
+                for member in new_members
+                for metadata in getattr(member, '__metadata__', tuple())
+                if _is_specialization(member, Annotated)
+            }
+            if only_explicit_bindings and _inject_marker not in union_metadata or _noinject_marker in union_metadata:
+                del bindings[k]
+            else:
+                bindings[k] = new_union  # type: ignore
 
     return bindings
 

--- a/injector_test.py
+++ b/injector_test.py
@@ -11,7 +11,7 @@
 """Functional tests for the "Injector" dependency injection framework."""
 
 from contextlib import contextmanager
-from typing import Any, NewType
+from typing import Any, NewType, Optional
 import abc
 import sys
 import threading
@@ -1484,3 +1484,16 @@ def test_get_bindings():
             pass
 
         assert get_bindings(function8) == {}
+
+    # Default arguments to NoInject annotations should behave the same as noninjectable decorator w.r.t 'None'
+    @inject
+    @noninjectable('b')
+    def function9(self, a: int, b: Optional[str] = None):
+        pass
+
+    @inject
+    def function10(self, a: int, b: NoInject[Optional[str]] = None):
+        # b:s type is Union[NoInject[Union[str, None]], None]
+        pass
+
+    assert get_bindings(function9) == {'a': int} == get_bindings(function10)


### PR DESCRIPTION
`NoInject[T | None] = None` has the runtime typehint `NoInject[T | None] | None`,
instead of the (at least to me) expected `NoInject[T | None]`, which causes the `NoInject` annotation inspections in `@inject` to fail where `@noninjectable` didn't.

`NoInject[str] = 'blarb'` has the typehint `NoInject[str]`, and `NoInject[str | None] = 'blarb'` typehints as `NoInject[str | None]`. I.e, `None` default arguments are treated separately when creating the runtime type.

There might be a case for a `NotImplementedError` to be raised in the case of a `Union` containing both `NoInject` and `Inject` annotations, but left it out. Behaviour now is to prioritize `NoInject` first, but allow a union which contains at least one `Inject`.

Resolves #190.