### PR TITLE
Do not check parent binder for `AssistedBuilder`

### DIFF
--- a/injector/__init__.py
+++ b/injector/__init__.py
@@ -651,8 +651,9 @@ class Binder:
 
     def get_binding(self, interface: type) -> Tuple[Binding, 'Binder']:
         is_scope = isinstance(interface, type) and issubclass(interface, Scope)
+        is_assisted_builder = _is_specialization(interface, AssistedBuilder)
         try:
-            return self._get_binding(interface, only_this_binder=is_scope)
+            return self._get_binding(interface, only_this_binder=is_scope or is_assisted_builder)
         except (KeyError, UnsatisfiedRequirement):
             if is_scope:
                 scope = interface

--- a/injector_test.py
+++ b/injector_test.py
@@ -801,10 +801,11 @@ def test_assisted_builder_injection_is_safe_to_use_with_multiple_injectors():
         def __init__(self, builder: AssistedBuilder[NeedsAssistance]):
             self.builder = builder
 
-    i1, i2= Injector(), Injector()
+    i1, i2 = Injector(), Injector()
     b1 = i1.get(X).builder
     b2 = i2.get(X).builder
     assert (b1._injector, b2._injector) == (i1, i2)
+
 
 def test_assisted_builder_injection_is_safe_to_use_with_child_injectors():
     class X:
@@ -817,6 +818,7 @@ def test_assisted_builder_injection_is_safe_to_use_with_child_injectors():
     b1 = i1.get(X).builder
     b2 = i2.get(X).builder
     assert (b1._injector, b2._injector) == (i1, i2)
+
 
 class TestThreadSafety:
     def setup(self):

--- a/injector_test.py
+++ b/injector_test.py
@@ -801,11 +801,22 @@ def test_assisted_builder_injection_is_safe_to_use_with_multiple_injectors():
         def __init__(self, builder: AssistedBuilder[NeedsAssistance]):
             self.builder = builder
 
-    i1, i2 = Injector(), Injector()
+    i1, i2= Injector(), Injector()
     b1 = i1.get(X).builder
     b2 = i2.get(X).builder
     assert (b1._injector, b2._injector) == (i1, i2)
 
+def test_assisted_builder_injection_is_safe_to_use_with_child_injectors():
+    class X:
+        @inject
+        def __init__(self, builder: AssistedBuilder[NeedsAssistance]):
+            self.builder = builder
+
+    i1 = Injector()
+    i2 = i1.create_child_injector()
+    b1 = i1.get(X).builder
+    b2 = i2.get(X).builder
+    assert (b1._injector, b2._injector) == (i1, i2)
 
 class TestThreadSafety:
     def setup(self):


### PR DESCRIPTION
Only check the current binder for bindings when resolving `AssistedBuilder` instances, since any injected argument to the built class should use the active injector when creating the `AssistedBuilder` and not one of its parents.

Fixes #186.