### PR TITLE
Use pypandoc.convert_file instead of pypandoc.convert

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ requirements_dev = list(obtain_requirements('requirements-dev.txt'))
 try:
     import pypandoc
 
-    long_description = pypandoc.convert('README.md', 'rst')
+    long_description = pypandoc.convert_file('README.md', 'rst')
 except ImportError:
     warnings.warn('Could not locate pandoc, using Markdown long_description.', ImportWarning)
     with open('README.md') as f:


### PR DESCRIPTION
This fixes an issue that breaks the build when using `pypandoc` 1.8 and above in which `convert` has been removed; see https://github.com/man-group/pytest-plugins/issues/87#issuecomment-1123830409